### PR TITLE
Fix: Allow closing help dialog by clicking background

### DIFF
--- a/components/help-dialog.tsx
+++ b/components/help-dialog.tsx
@@ -46,8 +46,14 @@ export default function HelpDialog() {
   });
 
   return (
-    <div className="fixed top-0 left-0 z-10 flex h-screen w-screen items-center justify-center bg-black/75 p-6">
-      <Card className="relative max-w-2xl text-sm">
+    <div
+      className="fixed top-0 left-0 z-10 flex h-screen w-screen items-center justify-center bg-black/75 p-6"
+      onClick={() => router.back()}
+    >
+      <Card
+        className="relative max-w-2xl text-sm"
+        onClick={(event) => event.stopPropagation()}
+      >
         <button
           className="absolute top-0 right-0 p-4 text-lg transition-colors hover:text-slate-600"
           onClick={() => router.back()}


### PR DESCRIPTION
I've modified the help dialog component so you can close it by clicking on the background overlay.

- I added an onClick handler to the background div that calls router.back().
- I also added an onClick handler to the dialog's content card that calls event.stopPropagation() to prevent clicks within the dialog from closing it.